### PR TITLE
Only check for class Resque if queue-option set

### DIFF
--- a/src/Airbrake/Client.php
+++ b/src/Airbrake/Client.php
@@ -90,7 +90,7 @@ class Client
      */
     public function notify(Notice $notice)
     {
-        if (class_exists('Resque') && $this->configuration->queue) {
+        if ($this->configuration->queue && class_exists('Resque') ) {
             //print_r($notice);exit;
             $data = array('notice' => serialize($notice), 'configuration' => serialize($this->configuration));
             \Resque::enqueue($this->configuration->queue, 'Airbrake\\Resque\\NotifyJob', $data);


### PR DESCRIPTION
class_exists will trigger autoload unless passed with false parameter
if we haven't defined a queue in the configuration there's no need
to trigger the autoloader for Resque
