### PR TITLE
Fix fsockopen over SSL

### DIFF
--- a/src/Airbrake/Connection.php
+++ b/src/Airbrake/Connection.php
@@ -79,7 +79,7 @@ class Connection
    * a response if the user has opted for async notifications
    */
   private function sendAsync(Notice $notice) {
-    $fp = fsockopen($this->configuration->host, $this->configuration->port);
+    $fp = fsockopen(($this->configuration->secure ? 'ssl://' : '') . $this->configuration->host, $this->configuration->port);
     if(!$fp) {
       return false;
     }


### PR DESCRIPTION
Only worked via port 80 without ssl:// prefixed to the hostname
